### PR TITLE
Fix zero-byte short-packet emulation

### DIFF
--- a/bochs/iodev/usb/usb_common.cc
+++ b/bochs/iodev/usb/usb_common.cc
@@ -49,22 +49,14 @@ bx_usbdev_ctl_c::bx_usbdev_ctl_c()
 
 void bx_usbdev_ctl_c::init(void)
 {
-  Bit8u i, j, count;
-
-  /*  If you wish to set DEBUG=report in the code, instead of
-   *  in the configuration, simply uncomment this line.  I use
-   *  it when I am working on this emulation.
-   */
-  //LOG_THIS setonoff(LOGLEV_DEBUG, ACT_REPORT);
-
-  count = PLUG_get_plugins_count(PLUGTYPE_USB);
+  Bit8u count = PLUG_get_plugins_count(PLUGTYPE_USB);
   usb_module_names = (const char**) malloc(count * sizeof(char*));
   usb_device_names = (const char**) malloc((count + 6) * sizeof(char*));
   usb_module_id = (Bit8u*) malloc((count + 5) * sizeof(Bit8u));
   usb_device_names[0] = "none";
   usb_module_id[0] = 0xff;
-  j = 1;
-  for (i = 0; i < count; i++) {
+  Bit8u j = 1;
+  for (Bit8u i = 0; i < count; i++) {
     usb_module_names[i] = PLUG_get_plugin_name(PLUGTYPE_USB, i);
     if (!strcmp(usb_module_names[i], "usb_hid")) {
       usb_device_names[j] = "mouse";
@@ -166,15 +158,15 @@ static const char *usb_speed[4] = {
 void bx_usbdev_ctl_c::parse_port_options(usb_device_c *device, bx_list_c *portconf)
 {
   const char *raw_options;
-  int i, optc, speed = USB_SPEED_FULL;  // assume FULL speed device if parameter not given.
+  int speed = device->get_default_speed(USB_SPEED_FULL);  // try to default to FULL speed if parameter not given.
   Bit8u devtype;
   char *opts[16];
 
   memset(opts, 0, sizeof(opts));
   devtype = ((bx_param_enum_c *) portconf->get_by_name("device"))->get();
   raw_options = ((bx_param_string_c *) portconf->get_by_name("options"))->getptr();
-  optc = bx_split_option_list("USB port options", raw_options, opts, 16);
-  for (i = 0; i < optc; i++) {
+  int optc = bx_split_option_list("USB port options", raw_options, opts, 16);
+  for (int i = 0; i < optc; i++) {
     if (!strncmp(opts[i], "speed:", 6)) {
       if (!strcmp(opts[i]+6, "low")) {
         speed = USB_SPEED_LOW;
@@ -195,7 +187,7 @@ void bx_usbdev_ctl_c::parse_port_options(usb_device_c *device, bx_list_c *portco
       BX_ERROR(("ignoring unknown USB device option: '%s'", opts[i]));
     }
   }
-  for (i = 0; i < optc; i++) {
+  for (int i = 0; i < optc; i++) {
     if (opts[i] != NULL) {
       free(opts[i]);
       opts[i] = NULL;

--- a/bochs/iodev/usb/usb_common.h
+++ b/bochs/iodev/usb/usb_common.h
@@ -237,6 +237,11 @@ public:
     }
   }
   int get_min_speed() { return d.minspeed; }
+  int get_default_speed(int speed) {
+    if ((speed >= d.minspeed) && (speed <= d.maxspeed))
+      return speed;
+    return d.minspeed; // will be no more than full-speed
+  }
   
   // return information for the specified ep of the current device
 #define USB_MAX_ENDPOINTS   5   // we currently don't use more than 5 endpoints (ep0, ep1, ep2, ep3, and ep4)
@@ -245,6 +250,9 @@ public:
   }
   int get_max_burst_size(const int ep) {
     return (ep < USB_MAX_ENDPOINTS) ? d.endpoint_info[ep].max_burst_size : 0;
+  }
+  int get_max_payload(const int ep) {
+    return (ep < USB_MAX_ENDPOINTS) ? (d.endpoint_info[ep].max_burst_size * d.endpoint_info[ep].max_packet_size) : 0;
   }
 
 #if HANDLE_TOGGLE_CONTROL
@@ -288,7 +296,7 @@ protected:
   struct {
     Bit8u type;
     bool connected;
-    int minspeed;
+    int minspeed;  // must be no more than FULL speed for *any* device
     int maxspeed;
     int speed;
     Bit8u addr;

--- a/bochs/iodev/usb/usb_hid.cc
+++ b/bochs/iodev/usb/usb_hid.cc
@@ -1600,9 +1600,10 @@ int usb_hid_device_c::handle_data(USBPacket *p)
       ret = USB_RET_STALL;
       break;
   }
-
-  if (ret > 0) usb_dump_packet(p->data, ret, 0, p->devaddr, p->devep, USB_TRANS_TYPE_BULK, false, true);
-
+  
+  if (ret > 0) usb_dump_packet(p->data, ret, 0, p->devaddr,
+    ((p->pid == USB_TOKEN_IN) ? USB_DIR_IN : USB_DIR_OUT) | p->devep, USB_TRANS_TYPE_INT, false, false);
+  
   return ret;
 }
 


### PR DESCRIPTION
- This PR allows the host controller to process Control EP zero-byte packets in case the Guest doesn't specify to use short packets or an even number of bytes is transferred where the data length lands on a max packet size boundary. The HC must still be allowed to process the next packet, even though it is a zero-length packet, to indicate a short-packet return. Before, the device went straight to the Status stage at the end of the data transfer. (Change effects Control transfers only)
- This PR tries to change the default speed to Full, defaulting to d.minspeed, if the speed is not specified.
- This PR allows a value of zero to be specified for a Configure request. A value of zero indicates to de-configure the device.
- This PR fixes the Packet Capture format of a HID device